### PR TITLE
Fixes and suggestions

### DIFF
--- a/webserver/trillian_client.py
+++ b/webserver/trillian_client.py
@@ -140,10 +140,11 @@ class TrillianLogClient():
             raise ValueError('`start` and `end` must be integers')
 
         if start < 0 or end < 0:
-            raise ValueError('`start` and `end` must be greater than zero')
+            raise ValueError(
+                    '`start` and `end` must be greater than or equal to zero')
 
-        if start >= end:
-            raise ValueError('`end` must be greater than `start`')
+        if start > end:
+            raise ValueError('`end` must be >= `start`')
 
         tree_size = self.get_tree_size()
 
@@ -184,7 +185,7 @@ class TrillianLogClient():
         if first_tree_size <= 0:
             raise ValueError('`first_tree_size` must be > 0')
 
-        if first_tree_size > second_tree_size:
+        if first_tree_size >= second_tree_size:
             raise ValueError('`first_tree_size` must be < `second_tree_size`')
 
         request = trillian_log_api_pb2.GetConsistencyProofRequest(

--- a/webserver/trillian_client.py
+++ b/webserver/trillian_client.py
@@ -85,8 +85,6 @@ class TrillianAdminClient():
 
 
 class TrillianLogClient():
-    MAX_LEAVES_PER_REQUEST = 1024
-
     def __init__(self, host, port, log_id):
         self.__channel = grpc.insecure_channel('{}:{}'.format(host, port))
         self.__stub = trillian_log_api_pb2_grpc.TrillianLogStub(self.__channel)
@@ -154,8 +152,6 @@ class TrillianLogClient():
                     start, tree_size
                 )
             )
-
-        end = min(start + self.MAX_LEAVES_PER_REQUEST, end)
 
         indexes = list(
             range(start, min(end, tree_size))


### PR DESCRIPTION
A few commits with suggestions:

-  Fixes where error descriptions don't match the condition causing the errors.

-  Trillian log servers will impose their own limit on number of entries returned, so let them worry about that and avoid potential for confusion when the range was trimmed locally, and then further trimmed remotely.

-  Prefer to use the `GetLeavesByRange` RPC call if possible, it's more efficient on the wire (2 ints rather than N, and many storage implementations will be able to service that request cheaper than N point lookups.
   Also refactor the various get-leaves methods to use the same underlying call.